### PR TITLE
 Add new firewalld_ipset option: manage_entries

### DIFF
--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -74,5 +74,16 @@ Puppet::Type.newtype(:firewalld_ipset) do
     desc "Timeout in seconds before entries expiry"
   end
 
+  newproperty(:manage_entries, :parent => Puppet::Parameter::Boolean) do
+    desc "Should we manage entries in this ipset or leave another process manage those entries"
+    defaultto true
+  end
+
+  validate do
+    if not self[:manage_entries] and self[:entries]
+      raise(Puppet::Error, "Ipset should not declare entries if it doesn't manage entries")
+    end
+  end
+
 end
   

--- a/spec/unit/puppet/provider/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_ipset_spec.rb
@@ -50,6 +50,7 @@ describe provider_class do
         resource.expects(:[]).with(:maxelem).returns(65_536).at_least_once
         resource.expects(:[]).with(:timeout).returns(nil).at_least_once
         resource.expects(:[]).with(:options).returns({}).at_least_once
+        resource.expects(:[]).with(:manage_entries).returns(true)
         resource.expects(:[]).with(:entries).returns(['192.168.0/24', '10.0.0/8'])
         provider.expects(:execute_firewall_cmd).with(['--new-ipset=white', '--type=hash:net', '--option=family=inet', '--option=hashsize=1024', '--option=maxelem=65536'], nil)
         provider.expects(:execute_firewall_cmd).with(['--ipset=white', '--add-entry=192.168.0/24'], nil)
@@ -70,6 +71,7 @@ describe provider_class do
         resource.expects(:[]).with(:maxelem).returns(nil).at_least_once
         resource.expects(:[]).with(:timeout).returns(nil).at_least_once
         resource.expects(:[]).with(:options).returns({}).at_least_once
+        resource.expects(:[]).with(:manage_entries).returns(true).at_least_once
         resource.expects(:[]).with(:entries).returns(['192.168.0/24', '10.0.0/8']).at_least_once
         provider.expects(:execute_firewall_cmd).with(['--new-ipset=white', '--type=hash:net', '--option=family=inet'], nil)
         provider.expects(:execute_firewall_cmd).with(['--new-ipset=white', '--type=hash:net', '--option=family=inet', '--option=hashsize=2048'], nil)
@@ -89,6 +91,7 @@ describe provider_class do
         resource.expects(:[]).with(:maxelem).returns(nil).at_least_once
         resource.expects(:[]).with(:timeout).returns(nil).at_least_once
         resource.expects(:[]).with(:options).returns({}).at_least_once
+        resource.expects(:[]).with(:manage_entries).returns(true).at_least_once
         resource.expects(:[]).with(:entries).returns(['192.168.0.0/24', '10.0.0.0/8']).at_least_once
         provider.expects(:entries).returns(['192.168.0.0/24', '10.0.0.0/8'])
         provider.expects(:execute_firewall_cmd).with(['--new-ipset=white', '--type=hash:net', '--option=family=inet'], nil)
@@ -99,6 +102,20 @@ describe provider_class do
         provider.create
         provider.entries = ['192.168.14.0/24', '10.0.0.0/8']
       end
+      it 'should ignore entries when manage_entries is false ' do
+        resource.expects(:[]).with(:name).returns('white').at_least_once
+        resource.expects(:[]).with(:type).returns('hash:net').at_least_once
+        resource.expects(:[]).with(:family).returns('inet').at_least_once
+        resource.expects(:[]).with(:hashsize).returns(nil)
+        resource.expects(:[]).with(:maxelem).returns(nil).at_least_once
+        resource.expects(:[]).with(:timeout).returns(nil).at_least_once
+        resource.expects(:[]).with(:options).returns({}).at_least_once
+        resource.expects(:[]).with(:manage_entries).returns(false).at_least_once
+        provider.expects(:execute_firewall_cmd).with(['--new-ipset=white', '--type=hash:net', '--option=family=inet'], nil)
+        provider.create
+        provider.entries = ['192.168.14.0/24', '10.0.0.0/8']
+      end
+
     end
   end
 end

--- a/spec/unit/puppet/type/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/type/firewalld_ipset_spec.rb
@@ -93,4 +93,15 @@ describe Puppet::Type.type(:firewalld_ipset) do
       expect(resource[:entries]).to eq ['8.8.8.8', '9.9.9.9']
     end
   end
+
+  context 'validation when not managing ipset entries ' do
+    it 'raises an error if wrong type' do
+      expect do Puppet::Type.type(:firewalld_ipset).new(
+        name: 'white',
+        type: 'hash:net',
+        manage_entries: false,
+        entries: ['8.8.8.8/32', '9.9.9.9']
+      ) end.to raise_error(/Ipset should not declare entries if it doesn't manage entries/)
+    end
+  end
 end


### PR DESCRIPTION
This pull request requires #170 to be merged first.

Sometimes firewalld ipset entries are modified by another process than puppet.
If you want to declare the ipset with puppet but not manage the entries,
we add the `manage_entries` option.

Obviously, by default entries are managed by puppet.

We throw an error if you try to define ipset entries with puppet and
don't want to manage entries (`manage_entries = false`)